### PR TITLE
Add link to a Sample App using Parse as Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of awesome Ionic libraries, resources and solutions.
 	- [Firebase Example](http://www.sitepoint.com/creating-firebase-powered-end-end-ionic-application/)
 	- [Syncing Data With Firebase](https://blog.nraboy.com/2014/12/syncing-data-firebase-using-ionic-framework/)
 	- [Parse REST API tutorial](http://www.htmlxprs.com/post/12/tutorial-on-using-parse-rest-api-and-ionic-framework-together) - Parse tutorial
+	- [Parse Sample App using angular-parse lib](https://github.com/giorgiofellipe/ionic-angular-parse-boilerplate)
 
 - Customization
 	- [Ionic material] (https://github.com/zachsoft/Ionic-Material)


### PR DESCRIPTION
It's a boilerplate from my own, developed using angular-parse (https://github.com/jimrhoskins/angular-parse) library.
